### PR TITLE
leave-maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,4 +45,3 @@ extra:
   recipe-maintainers:
     - almarklein
     - ivoflipse
-    - korijn 


### PR DESCRIPTION
I no longer wish to maintain conda packages, so I'm editing myself out of the maintainers in the recipes.